### PR TITLE
api: add session PATCH support

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,3 +15,5 @@ tempfile = "3.2"
 tide = "0.16"
 async-std = { version = "1.8.0", features = ["attributes"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+json-patch = "0.2"

--- a/api/example/session-get.sh
+++ b/api/example/session-get.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+curl -XGET "http://localhost:3000/api/v1/sss/combine/$(cat session-id.b64)"

--- a/api/example/session-id.b64
+++ b/api/example/session-id.b64
@@ -1,0 +1,1 @@
+wdFy1cFmCEExNPAthqEzE6bhAEBUpeTszNSwcK1KfTE=

--- a/api/example/session-patch.json
+++ b/api/example/session-patch.json
@@ -1,0 +1,4 @@
+{ 
+  "share": "b64(encrypted(share))", 
+  "confidant": { "pubkey": "b64(pubkey)" }
+}

--- a/api/example/session-patch.sh
+++ b/api/example/session-patch.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+curl -XPATCH "http://localhost:3000/api/v1/sss/combine/$(cat session-id.b64)" \
+    --data-binary @session-patch.json

--- a/api/example/session-put.json
+++ b/api/example/session-put.json
@@ -1,0 +1,1 @@
+{ "user": { "cid": "b64(argon2d(client-phone))" } }

--- a/api/example/session-put.sh
+++ b/api/example/session-put.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+curl -XPUT "http://localhost:3000/api/v1/sss/combine/$(cat session-id.b64)" \
+    --data-binary @session-put.json


### PR DESCRIPTION
Use the json_patch crate and for now the json merge patch strategy:

    https://tools.ietf.org/html/rfc7386

Possible we may want a patch document but for now there's no reason we
need to support fields with null values.