### PR TITLE
cli: add support for additional data and mu

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2018"
 name = "uno"
 path = "src/main.rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 uno = "0.1.0"
 djb = "0.1.0"
@@ -18,7 +16,7 @@ djb = "0.1.0"
 anyhow = "1.0"
 async-std = "1.9"
 base64 = "0.13"
-clap = "3.0.0-beta.2"
+clap = { version = "3.0.0-beta.2", features = ["wrap_help"] }
 chrono = "0.4"
 http-types = "2.10"
 serde = { version = "1.0", features = ["derive"] }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -150,9 +150,9 @@ const SHARE: &str = "share";
 const USER: &str = "user";
 
 #[derive(Debug)]
-enum Inference
+enum Inference<'a>
 {
-    Exact(Binding),
+    Exact(Binding<'a>),
     Unknown,
 }
 


### PR DESCRIPTION
You can now specify `--bind` or `--data` to provide context to the
encrypt and decrypt commands. You can also encrypt and decrypt with
a Mu seed using `--mu` instead of `--seed`.