### PR TITLE
remove pointless object store request

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -112,12 +112,9 @@ pub async fn post_message(
     let j = serde_json::to_vec(&m)?;
 
     store.put(&dest, &j).await?;
-
-    let b2 = store.get(&dest).await?;
-    let m2: MessageStored = serde_json::from_slice(&b2)?;
     // UNLOCK
 
-    Ok(m2)
+    Ok(m)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We don't need to make a separate request to confirm the object was created. If something failed, it should be reflected in the error response...