### PR TITLE
uno-assistant: add initial groundwork

### DIFF
--- a/.github/workflows/create-do-app.yml
+++ b/.github/workflows/create-do-app.yml
@@ -63,7 +63,7 @@ jobs:
                   scope: RUN_TIME
                 - key: TWILIO_SERVICE_SID
                   value: ${{ secrets.TWILIO_SERVICE_SID }}
-                  scope: RUN_TIME                
+                  scope: RUN_TIME
                   type: SECRET
                 - key: TWILIO_ACCOUNT_SID
                   value: ${{ secrets.TWILIO_ACCOUNT_SID }}
@@ -92,6 +92,14 @@ jobs:
                 - key: PUBLIC_URL
                   value: \${_self.PUBLIC_URL}
                   scope: RUN_TIME
+                - key: OPENAI_API_KEY
+                  value: ${{ secrets.OPENAI_API_KEY }}
+                  type: SECRET
+                  scope: RUN_TIME
+                - key: ASSISTANT_ENDPOINT
+                  value: ${{ secrets.ASSISTANT_ENDPOINT }}
+                  type: SECRET
+                  scope: RUN_TIME
           EOF
 
       - name: Validate App Spec
@@ -112,4 +120,3 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message: "Started deployment https://cloud.digitalocean.com/apps/${{ steps.app.outputs.id }}/deployments"
-

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [features]
 s3 = []
 twilio = []
+openai = []
 
 [dependencies]
 anyhow = "1.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -25,7 +25,7 @@ json-patch = "0.2"
 password-hash = "0.2"
 rand = "0.8"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
-rusty-s3 = "0.3"
+rusty-s3 = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,7 +2,7 @@ FROM rustlang/rust:nightly as builder
 WORKDIR /app
 COPY . .
 RUN cargo +nightly test --release
-RUN cargo +nightly install --path api --root . --features "s3 twilio"
+RUN cargo +nightly install --path api --root . --features "s3 twilio openai"
 
 FROM debian:buster-slim
 RUN apt update && apt install -y libcurl4
@@ -10,4 +10,3 @@ WORKDIR /root
 EXPOSE 8080
 COPY --from=builder /app/bin/ /usr/local/bin/
 CMD [ "api" ]
-

--- a/api/src/assistant.rs
+++ b/api/src/assistant.rs
@@ -5,24 +5,33 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use anyhow::Context;
 use http_types::Status;
 use http_types::StatusCode;
 use serde::{Deserialize, Serialize};
 
+use strum_macros::AsRefStr;
+use strum_macros::EnumString;
+
 use tide::Response;
 use tide::Result;
 
-// unused
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AssistTopicLookup
 {
-    // enum one of: password-reset, enable-2fa
+    // Topic enum one of: reset-password, enable-2fa
     pub topic: String,
     pub domain: String,
 }
 
-// unused
+#[derive(Debug, PartialEq, AsRefStr, EnumString)]
+pub enum Topic
+{
+    #[strum(serialize = "reset-password")]
+    ResetPassword,
+    #[strum(serialize = "enable-2fa")]
+    Enable2FA,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AssistTopicResponse
 {

--- a/api/src/assistant.rs
+++ b/api/src/assistant.rs
@@ -47,8 +47,13 @@ pub async fn passthrough(req_bytes: Vec<u8>) -> Result<Response>
     let lambda = std::env::var("ASSISTANT_ENDPOINT")
         .status(StatusCode::InternalServerError)?;
 
-    let mut surf_response = surf::post(lambda).body_bytes(req_bytes).await?;
+    let mut surf_response = surf::post(lambda)
+        .header("content-type", "application/json")
+        .body_bytes(req_bytes)
+        .await?;
+
     let tide_response = Response::builder(surf_response.status())
+        .header("content-type", "application/json")
         .body(surf_response.body_bytes().await?)
         .build();
 

--- a/api/src/assistant.rs
+++ b/api/src/assistant.rs
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2023 WithUno, Inc.
+// All rights reserved.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use anyhow::Context;
+use http_types::Status;
+use http_types::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use tide::Response;
+use tide::Result;
+
+// unused
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AssistTopicLookup
+{
+    // enum one of: password-reset, enable-2fa
+    pub topic: String,
+    pub domain: String,
+}
+
+// unused
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AssistTopicResponse
+{
+    /// List of steps the user should take
+    pub steps: Vec<String>,
+    /// URL linking the user to the first step
+    pub action_url: String,
+}
+
+pub async fn passthrough(req_bytes: Vec<u8>) -> Result<Response>
+{
+    // use the serverless function
+    let lambda = std::env::var("ASSISTANT_ENDPOINT")
+        .status(StatusCode::InternalServerError)?;
+
+    let mut surf_response = surf::post(lambda).body_bytes(req_bytes).await?;
+    let tide_response = Response::builder(surf_response.status())
+        .body(surf_response.body_bytes().await?)
+        .build();
+
+    Ok(tide_response)
+}

--- a/api/src/assistant.rs
+++ b/api/src/assistant.rs
@@ -38,7 +38,7 @@ pub async fn passthrough(req_bytes: Vec<u8>) -> Result<Response>
     let lambda = std::env::var("ASSISTANT_ENDPOINT")
         .status(StatusCode::InternalServerError)?;
 
-    let mut surf_response = surf::post(lambda).body_bytes(req_bytes).await?;
+    let mut surf_response = surf::get(lambda).body_bytes(req_bytes).await?;
     let tide_response = Response::builder(surf_response.status())
         .body(surf_response.body_bytes().await?)
         .build();

--- a/api/src/assistant.rs
+++ b/api/src/assistant.rs
@@ -47,7 +47,7 @@ pub async fn passthrough(req_bytes: Vec<u8>) -> Result<Response>
     let lambda = std::env::var("ASSISTANT_ENDPOINT")
         .status(StatusCode::InternalServerError)?;
 
-    let mut surf_response = surf::get(lambda).body_bytes(req_bytes).await?;
+    let mut surf_response = surf::post(lambda).body_bytes(req_bytes).await?;
     let tide_response = Response::builder(surf_response.status())
         .body(surf_response.body_bytes().await?)
         .build();

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -43,7 +43,7 @@ use tide::{Body, Error, Next, Request, Response, Result, StatusCode};
 
 mod twilio;
 
-mod assistant;
+pub mod assistant;
 
 /// Enforce a global size limit on the body of requests
 ///

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -61,6 +61,17 @@ async fn main() -> Result<()>
             .context("twilio API endpoint must be a url")?;
     }
 
+    if cfg!(feature = "openai") && cfg!(not(test)) {
+        let _ = std::env::var("OPENAI_API_KEY")
+            .context("Must specify OPENAI_API_KEY")?;
+    }
+    if cfg!(feature = "openai") && cfg!(not(test)) {
+        let _: surf::Url = std::env::var("ASSISTANT_ENDPOINT")
+            .context("Must specify ASSISTANT_ENDPOINT")?
+            .parse()
+            .context("ASSISTANT_ENDPOINT must be a valid URL")?;
+    }
+
     let tok2 = make_db("tokens", "v2").await?;
     let vau2 = make_db("vaults", "v2").await?;
     let srv2 = make_db("services", "").await?; // not (yet) versioned
@@ -69,9 +80,11 @@ async fn main() -> Result<()>
     let shr2 = make_db("shares", "v2").await?;
     let vdb2 = make_db("verify", "v2").await?;
     let dir2 = make_db("directory", "v2").await?;
+    let ast2 = make_db("assistant", "v2").await?; // db is empty right now
 
-    let api_v2 =
-        api::build_routes(tok2, vau2, srv2, ses2, mbx2, shr2, vdb2, dir2)?;
+    let api_v2 = api::build_routes(
+        tok2, vau2, srv2, ses2, mbx2, shr2, vdb2, dir2, ast2,
+    )?;
 
     let mut srv = tide::new();
 

--- a/api/src/twilio.rs
+++ b/api/src/twilio.rs
@@ -1,4 +1,11 @@
 //
+// Copyright (C) 2022 WithUno, Inc.
+// All rights reserved.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+//
 // Twilio boilerplate
 //
 

--- a/api/tests/requests.rs
+++ b/api/tests/requests.rs
@@ -2454,10 +2454,10 @@ mod requests
         let id = Id([0u8; ID_LENGTH]); // use the zero id
 
         let resource = "http://example.com/assist/topics";
-        let json = json!({ "topic": "password-reset", "domain": "foo.bar" });
+        let json1 = json!({ "topic": "reset-password", "domain": "foo.bar" });
 
         let mut req1: Request = surf::post(&resource)
-            .body_json(&json)
+            .body_json(&json1)
             .map_err(|e| anyhow!(e))?
             .build();
 
@@ -2467,6 +2467,19 @@ mod requests
             api.respond(req1).await.map_err(|_| anyhow!("request failed"))?;
 
         assert_eq!(StatusCode::Ok, res1.status());
+
+        let json2 = json!({ "topic": "enable-2fa", "domain": "baz.qux" });
+        let mut req2: Request = surf::get(&resource)
+            .body_json(&json2)
+            .map_err(|e| anyhow!(e))?
+            .build();
+
+        asym_sign_req_using_res_with_id(&res1, &mut req2, &id)?;
+
+        let res2: Response =
+            api.respond(req2).await.map_err(|_| anyhow!("request failed"))?;
+
+        assert_eq!(StatusCode::Ok, res2.status());
 
         Ok(())
     }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ api = { path = "../api" }
 uno = { path = "../lib" }
 djb = { path = "../djb" }
 
+ansi_term = "0.12"
 anyhow = "1.0"
 argon2 = "0.2"
 async-std = "1.9"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1240,8 +1240,10 @@ fn do_assistant_resetpw(
         None => cli::load_seed(&cfg)?,
     };
     let url = opts.url.as_ref().unwrap_or(&cfg.api_host);
-
     let topic = api::assistant::Topic::ResetPassword;
+
+    assistant_thinking();
+
     let result = cli::get_assistance(url, &id, &c.domain, topic)?;
 
     Ok(result)
@@ -1270,11 +1272,19 @@ fn do_assistant_enable2fa(
         None => cli::load_seed(&cfg)?,
     };
     let url = opts.url.as_ref().unwrap_or(&cfg.api_host);
-
     let topic = api::assistant::Topic::Enable2FA;
+
+    assistant_thinking();
+
     let result = cli::get_assistance(url, &id, &c.domain, topic)?;
 
     Ok(result)
+}
+
+fn assistant_thinking()
+{
+    use ansi_term::Style;
+    println!("{}", Style::new().italic().paint("Thinking..."));
 }
 
 fn main() -> Result<()>

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,6 +83,9 @@ enum SubCommand
 
     #[clap(display_order = 90)]
     Directory(DirectoryCmd),
+
+    #[clap(display_order = 100)]
+    Assistant(AssistantCmd),
 }
 
 ///
@@ -1168,6 +1171,111 @@ fn do_directory_verify(
     Ok(result)
 }
 
+///
+/// Get help from the Uno assistant.
+///
+#[derive(Parser)]
+struct AssistantCmd
+{
+    #[clap(subcommand)]
+    subcmd: Assistant,
+    #[clap(flatten)]
+    opts: AssistantOpts,
+}
+
+#[derive(Parser)]
+struct AssistantOpts
+{
+    /// Assistant service API endpoint. If specified, supersedes the configured
+    /// value.
+    #[clap(long, value_name = "endpoint", display_order = 1)]
+    url: Option<String>,
+
+    /// Identity seed to use. If specified, supersedes the configured value.
+    #[clap(long, value_name = "b64", display_order = 1)]
+    seed: Option<String>,
+}
+
+///
+/// Assistant subcommands
+///
+#[derive(Parser)]
+enum Assistant
+{
+    #[clap(display_order = 1)]
+    ResetPassword(AssistantResetPassword),
+
+    #[clap(display_order = 2, name = "enable-2fa")]
+    Enable2FA(AssistantEnable2FA),
+}
+
+fn do_assistant(ctx: Context, s: AssistantCmd) -> Result<String>
+{
+    match s.subcmd {
+        Assistant::ResetPassword(c) => do_assistant_resetpw(ctx, s.opts, c),
+        Assistant::Enable2FA(c) => do_assistant_enable2fa(ctx, s.opts, c),
+    }
+}
+
+///
+/// Get password reset instructions for the requested website.
+///
+#[derive(Parser)]
+struct AssistantResetPassword
+{
+    /// The website's domain or host name.
+    #[clap(long, value_name = "example.com", display_order = 1)]
+    domain: String,
+}
+
+fn do_assistant_resetpw(
+    ctx: Context,
+    opts: AssistantOpts,
+    c: AssistantResetPassword,
+) -> Result<String>
+{
+    let cfg = load_conf(&ctx)?;
+    let id = match opts.seed {
+        Some(s) => id_from_b64(s)?,
+        None => cli::load_seed(&cfg)?,
+    };
+    let url = opts.url.as_ref().unwrap_or(&cfg.api_host);
+
+    let topic = api::assistant::Topic::ResetPassword;
+    let result = cli::get_assistance(url, &id, &c.domain, topic)?;
+
+    Ok(result)
+}
+
+///
+/// Get 2FA setup instructions for the requested website.
+///
+#[derive(Parser)]
+struct AssistantEnable2FA
+{
+    /// The website's domain or host name.
+    #[clap(long, value_name = "example.com", display_order = 1)]
+    domain: String,
+}
+
+fn do_assistant_enable2fa(
+    ctx: Context,
+    opts: AssistantOpts,
+    c: AssistantEnable2FA,
+) -> Result<String>
+{
+    let cfg = load_conf(&ctx)?;
+    let id = match opts.seed {
+        Some(s) => id_from_b64(s)?,
+        None => cli::load_seed(&cfg)?,
+    };
+    let url = opts.url.as_ref().unwrap_or(&cfg.api_host);
+
+    let topic = api::assistant::Topic::Enable2FA;
+    let result = cli::get_assistance(url, &id, &c.domain, topic)?;
+
+    Ok(result)
+}
 
 fn main() -> Result<()>
 {
@@ -1190,6 +1298,7 @@ fn main() -> Result<()>
         SubCommand::S39(cmd) => do_s39(ctx, cmd),
         SubCommand::Account(cmd) => do_account(ctx, cmd),
         SubCommand::Directory(cmd) => do_directory(ctx, cmd),
+        SubCommand::Assistant(cmd) => do_assistant(ctx, cmd),
     }?;
 
     println!("{}", out);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -446,7 +446,7 @@ pub extern "C" fn uno_free_group_split(group_split: UnoGroupSplit)
     // SAFETY: we generated these values ourself, mbs is opaque
     unsafe {
         Vec::from_raw_parts(mbs.ptr.as_ptr(), mbs.len, mbs.cap);
-        Box::from_raw(raw);
+        drop(Box::from_raw(raw));
     };
 }
 


### PR DESCRIPTION
Call the lambda for now. The end goal is to port the logic from the DO serverless function into this repo, since we don't have auth on the serverless endpoint, but there's some entropy in the url and it's not a huge deal to use it for now while things mature.