### PR TITLE
project: add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+


### PR DESCRIPTION
Now you don't have to remember to use nightl when running fmt, and zed works without lint errors.